### PR TITLE
Create redesigned onboarding splash and welcome flow

### DIFF
--- a/youspeak-app/components/icons/SmileArcIcon.tsx
+++ b/youspeak-app/components/icons/SmileArcIcon.tsx
@@ -1,0 +1,18 @@
+import type { FC } from 'react';
+import Svg, { Path } from 'react-native-svg';
+
+export type SmileArcIconProps = {
+  width?: number;
+  color?: string;
+};
+
+const SmileArcIcon: FC<SmileArcIconProps> = ({ width = 200, color = '#FFFFFF' }) => {
+  const height = width / 3.2;
+  return (
+    <Svg width={width} height={height} viewBox="0 0 200 64" fill="none">
+      <Path d="M16 16C56 72 144 72 184 16" stroke={color} strokeWidth={12} strokeLinecap="round" />
+    </Svg>
+  );
+};
+
+export default SmileArcIcon;

--- a/youspeak-app/declarations.d.ts
+++ b/youspeak-app/declarations.d.ts
@@ -1,0 +1,6 @@
+declare module '*.svg' {
+  import type { FC } from 'react';
+  import type { SvgProps } from 'react-native-svg';
+  const content: FC<SvgProps>;
+  export default content;
+}

--- a/youspeak-app/navigation/AppNavigator.tsx
+++ b/youspeak-app/navigation/AppNavigator.tsx
@@ -4,8 +4,12 @@ import type { JSX } from 'react';
 
 import HomeScreen from '../screens/HomeScreen';
 import LearnScreen from '../screens/LearnScreen';
+import SplashScreen from '../screens/SplashScreen';
+import WelcomeScreen from '../screens/WelcomeScreen';
 
 type RootStackParamList = {
+  Splash: undefined;
+  Welcome: undefined;
   Home: undefined;
   Learn: undefined;
 };
@@ -15,7 +19,9 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
 const AppNavigator = (): JSX.Element => {
   return (
     <NavigationContainer>
-      <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Navigator screenOptions={{ headerShown: false }} initialRouteName="Splash">
+        <Stack.Screen name="Splash" component={SplashScreen} />
+        <Stack.Screen name="Welcome" component={WelcomeScreen} />
         <Stack.Screen name="Home" component={HomeScreen} />
         <Stack.Screen name="Learn" component={LearnScreen} />
       </Stack.Navigator>

--- a/youspeak-app/screens/HomeScreen.tsx
+++ b/youspeak-app/screens/HomeScreen.tsx
@@ -5,57 +5,50 @@ import type { JSX } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 
-import StageRow, { type StageRowProps } from '../components/StageRow';
-
-import LightBulbIcon from '../components/icons/LightBulbIcon';
+import SmileIcon from '../components/icons/SmileIcon';
 import type { RootStackParamList } from '../navigation/AppNavigator';
-
-type Stage = StageRowProps;
-
-const stages: Stage[] = [
-  { label: 'Learn It.', icons: ['plus'] },
-  { label: 'Speak It.', icons: ['plus', 'smile'] },
-  { label: 'Live It.', icons: ['plus', 'smile', 'smile'] },
-];
 
 type HomeScreenProps = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
 const HomeScreen = ({ navigation }: HomeScreenProps): JSX.Element => {
   return (
     <LinearGradient
-      colors={['#4C1D95', '#1F9DF1']}
+      colors={['#2F0B65', '#0A5FCF']}
       start={{ x: 0, y: 0 }}
-      end={{ x: 0.8, y: 1 }}
+      end={{ x: 0.9, y: 1 }}
       className="flex-1"
     >
       <SafeAreaView className="flex-1 px-8">
         <StatusBar style="light" />
-        <View className="flex-1 items-center justify-center py-12">
-          <View className="items-center gap-8 ">
-            <View className="items-center gap-2 ">
-              <Text className="text-white text-6xl font-spaceGrotesk font-semibold tracking-[6px] uppercase">
-                YOU
-              </Text>
-              <Text className="text-white text-6xl font-spaceGrotesk font-semibold">Speak</Text>
+        <View className="flex-1 justify-between py-16">
+          <View className="items-center gap-12">
+            <View className="flex-row items-center justify-center gap-6">
+              {[0, 1, 2].map((index) => (
+                <View
+                  key={index}
+                  className="h-20 w-20 items-center justify-center rounded-full border-2 border-[#FACC15] bg-white/10"
+                >
+                  <SmileIcon size={52} color="#FACC15" />
+                </View>
+              ))}
             </View>
-            <View className="h-28 w-28 items-center justify-center rounded-full border border-white/20 bg-white/10">
-              <LightBulbIcon size={42} />
-            </View>
-            {/* <Image source={require('../assets/splash-icon.png')} /> */}
-          </View>
 
-          <View className="items-center gap-6">
-            {stages.map((stage) => (
-              <StageRow key={stage.label} label={stage.label} icons={stage.icons} />
-            ))}
+            <View className="items-center gap-4 px-6">
+              <Text className="text-center text-3xl font-spaceGrotesk font-semibold text-white">
+                Learn It. Speak It. Live It.
+              </Text>
+              <Text className="text-center text-base font-spaceGrotesk text-white/80">
+                Develop real-world speaking confidence with guided practice every day.
+              </Text>
+            </View>
           </View>
 
           <TouchableOpacity
-            activeOpacity={0.8}
-            className="w-full rounded-full border border-white/30 bg-white/15 py-4"
+            activeOpacity={0.85}
+            className="w-full rounded-full bg-white py-4"
             onPress={() => navigation.navigate('Learn')}
           >
-            <Text className="text-center text-lg font-spaceGrotesk font-semibold uppercase tracking-[4px] text-white">
+            <Text className="text-center text-lg font-spaceGrotesk font-semibold text-[#2F0B65]">
               Start Learning
             </Text>
           </TouchableOpacity>

--- a/youspeak-app/screens/SplashScreen.tsx
+++ b/youspeak-app/screens/SplashScreen.tsx
@@ -1,0 +1,65 @@
+import { StatusBar } from 'expo-status-bar';
+import { LinearGradient } from 'expo-linear-gradient';
+import type { JSX } from 'react';
+import { useEffect } from 'react';
+import { Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+import SmileArcIcon from '../components/icons/SmileArcIcon';
+import type { RootStackParamList } from '../navigation/AppNavigator';
+
+const gradientColors = ['#2F0B65', '#0A5FCF'];
+
+const wordmarkTextClassName =
+  'text-white text-6xl font-spaceGrotesk font-semibold tracking-[8px] uppercase';
+
+const speechBubbleClassName =
+  'h-16 w-16 items-center justify-center rounded-full border-2 border-white bg-white/10';
+
+type SplashScreenProps = NativeStackScreenProps<RootStackParamList, 'Splash'>;
+
+const SplashScreen = ({ navigation }: SplashScreenProps): JSX.Element => {
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      navigation.replace('Welcome');
+    }, 1600);
+
+    return () => clearTimeout(timeout);
+  }, [navigation]);
+
+  return (
+    <LinearGradient colors={gradientColors} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} className="flex-1">
+      <SafeAreaView className="flex-1">
+        <StatusBar style="light" />
+        <View className="flex-1 items-center justify-center gap-16">
+          <View className="items-center gap-6">
+            <View className="flex-row items-center gap-4">
+              <Text className={wordmarkTextClassName}>Y</Text>
+              <View className={speechBubbleClassName}>
+                <View className="h-8 w-8 rounded-full border-2 border-white bg-white/85" />
+                <View className="mt-1 h-1.5 w-6 rounded-full bg-white/85" />
+              </View>
+              <Text className={wordmarkTextClassName}>U</Text>
+            </View>
+            <Text className="text-white text-6xl font-spaceGrotesk font-semibold tracking-[6px]">
+              Speak
+            </Text>
+            <SmileArcIcon width={180} color="#FFFFFF" />
+          </View>
+
+          <View className="items-center gap-3 px-12">
+            <Text className="text-center text-lg font-spaceGrotesk font-medium uppercase tracking-[4px] text-white/80">
+              Learn. Speak. Live.
+            </Text>
+            <Text className="text-center text-base font-spaceGrotesk text-white/70">
+              Your everyday speaking companion built to boost confidence and fluency.
+            </Text>
+          </View>
+        </View>
+      </SafeAreaView>
+    </LinearGradient>
+  );
+};
+
+export default SplashScreen;

--- a/youspeak-app/screens/WelcomeScreen.tsx
+++ b/youspeak-app/screens/WelcomeScreen.tsx
@@ -1,0 +1,74 @@
+import { StatusBar } from 'expo-status-bar';
+import type { JSX } from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+import WelcomeIllustration from '../assets/illustrations/welcome-screen.svg';
+import type { RootStackParamList } from '../navigation/AppNavigator';
+
+const dotClassName = 'h-2.5 w-2.5 rounded-full';
+const primaryColor = '#4C1D95';
+
+const cardShadowStyle = {
+  shadowColor: '#0F172A',
+  shadowOffset: { width: 0, height: 10 },
+  shadowOpacity: 0.08,
+  shadowRadius: 20,
+  elevation: 6,
+};
+
+type WelcomeScreenProps = NativeStackScreenProps<RootStackParamList, 'Welcome'>;
+
+const WelcomeScreen = ({ navigation }: WelcomeScreenProps): JSX.Element => {
+  return (
+    <View className="flex-1 bg-white">
+      <SafeAreaView className="flex-1 px-6">
+        <StatusBar style="dark" />
+        <View className="flex-1 justify-center gap-12 py-10">
+          <View className="items-center rounded-3xl border border-slate-100 bg-white px-6 py-12" style={cardShadowStyle}>
+            <View className="h-48 w-full items-center justify-center">
+              <WelcomeIllustration width="100%" height="100%" />
+            </View>
+
+            <View className="mt-8 items-center gap-3">
+              <Text className="text-center text-2xl font-spaceGrotesk font-semibold text-slate-900">
+                Speak with confidence
+              </Text>
+              <Text className="text-center text-base font-spaceGrotesk text-slate-500">
+                Practice conversations daily and improve naturally.
+              </Text>
+            </View>
+
+            <View className="mt-8 flex-row items-center justify-center gap-2">
+              <View className={`${dotClassName} bg-slate-200`} />
+              <View className={dotClassName} style={{ backgroundColor: primaryColor }} />
+              <View className={`${dotClassName} bg-slate-200`} />
+            </View>
+          </View>
+
+          <View className="gap-6">
+            <TouchableOpacity
+              activeOpacity={0.85}
+              className="rounded-full bg-[#4C1D95] py-4"
+              onPress={() => navigation.replace('Home')}
+            >
+              <Text className="text-center text-lg font-spaceGrotesk font-semibold text-white">Get Started</Text>
+            </TouchableOpacity>
+
+            <View className="flex-row justify-center gap-2">
+              <Text className="text-base font-spaceGrotesk text-slate-500">Already have an account?</Text>
+              <TouchableOpacity activeOpacity={0.7} onPress={() => navigation.replace('Home')}>
+                <Text className="text-base font-spaceGrotesk font-semibold" style={{ color: primaryColor }}>
+                  Log in
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </SafeAreaView>
+    </View>
+  );
+};
+
+export default WelcomeScreen;

--- a/youspeak-app/tsconfig.json
+++ b/youspeak-app/tsconfig.json
@@ -1,4 +1,5 @@
 {
   "compilerOptions": {},
-  "extends": "expo/tsconfig.base"
+  "extends": "expo/tsconfig.base",
+  "include": ["**/*.ts", "**/*.tsx", "declarations.d.ts"]
 }


### PR DESCRIPTION
## Summary
- add a dedicated splash screen with branded gradient wordmark and automatic handoff to onboarding
- create a welcome screen illustration card and CTA before landing on the refreshed home screen
- restyle the home screen and navigation stack while adding svg typing support for the new assets

## Testing
- pnpm exec tsc --noEmit *(fails: project dependencies are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ae4e3dc8832ba42e5f9f37e84cc3